### PR TITLE
refactor: single source of truth for mobile breakpoint

### DIFF
--- a/src/app/layouts/app-layout/sidebar-state.service.ts
+++ b/src/app/layouts/app-layout/sidebar-state.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, computed, effect, signal } from '@angular/core';
+import { MOBILE_QUERY } from '../../shared/constants';
 
 const SIDEBAR_LOCKED_KEY = 'app:sidebar-locked';
-const MOBILE_QUERY = '(max-width: 991px)';
 
 @Injectable({ providedIn: 'root' })
 export class SidebarStateService {
@@ -16,7 +16,7 @@ export class SidebarStateService {
       try {
         localStorage.setItem(SIDEBAR_LOCKED_KEY, String(this.locked()));
       } catch {
-        // localStorage unavailable — ignore
+        // localStorage unavailable \u2014 ignore
       }
     });
 

--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -1,0 +1,2 @@
+export const MOBILE_BREAKPOINT = 991;
+export const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT}px)`;

--- a/src/styles/_breakpoints.scss
+++ b/src/styles/_breakpoints.scss
@@ -1,1 +1,5 @@
+// Keep in sync with src/app/shared/constants.ts (MOBILE_BREAKPOINT)
+:root {
+  --breakpoint-mobile: 991px;
+}
 $breakpoint-mobile: 991px;


### PR DESCRIPTION
Fixes #3\n\n- Extracts the mobile breakpoint into  so TS has one source of truth.\n- Updates  to import  from the shared constant.\n- Adds a CSS custom property on  in  and a sync comment so the two files don't drift silently.